### PR TITLE
emphasize additional authority warnings

### DIFF
--- a/pages/reference/index.md
+++ b/pages/reference/index.md
@@ -137,7 +137,7 @@ UTF-8
 
 ## メッセージ一覧の取得 [GET /rooms/{room_id}/messages]
 
-このAPIにアクセスするためには、追加の権限が必要です。BOCCOサポートにお問い合わせください。
+<span style="color:red">**このAPIにアクセスするためには、追加の権限が必要です。BOCCOサポートにお問い合わせください。**</span>
 
 ### リクエスト
 
@@ -318,7 +318,7 @@ audio
 
 ## イベントの取得 [GET /rooms/{room_id}/subscribe]
 
-このAPIにアクセスするためには、追加の権限が必要です。BOCCOサポートにお問い合わせください。
+<span style="color:red">**このAPIにアクセスするためには、追加の権限が必要です。BOCCOサポートにお問い合わせください。**</span>
 
 ### リクエスト
 
@@ -402,7 +402,7 @@ audio
 
 ## メッセージを既読にする [POST /rooms/{room_id}/messages/{message_id}/read]
 
-このAPIにアクセスするためには、追加の権限が必要です。BOCCOサポートにお問い合わせください。
+<span style="color:red">**このAPIにアクセスするためには、追加の権限が必要です。BOCCOサポートにお問い合わせください。**</span>
 
 ### リクエスト
 


### PR DESCRIPTION
`このAPIにアクセスするためには、追加の権限が必要です。BOCCOサポートにお問い合わせください。`

の文言が見づらかったため、目立たせるように赤文字にしています。
