### PR TITLE
fix markdown typo at get_joined_rooms.md

### DIFF
--- a/pages/tutorial/get_joined_rooms.md
+++ b/pages/tutorial/get_joined_rooms.md
@@ -120,7 +120,8 @@ Content-Type: application/json; charset=utf-8
 Vary: Accept-Encoding
 Date: Thu, 08 Sep 2016 08:40:55 GMT
 Content-Length: 40
-Via: 1.1 vegur```
+Via: 1.1 vegur
+```
 
 レスポンスBody
 


### PR DESCRIPTION
チュートリアル/チャットルームを取得するの[ここ](http://api-docs.bocco.me/get_joined_rooms.html#section-5)にMarkdownのエラーがあったので修正しました
