### PR TITLE
remove sidebar at tag_tutorial page

### DIFF
--- a/pages/tags/tag_tutorial.md
+++ b/pages/tags/tag_tutorial.md
@@ -3,7 +3,7 @@ title: "tutorial タグが付いたページ一覧"
 tagName: tutorial
 search: exclude
 permalink: tag_tutorial.html
-sidebar: mydoc_sidebar
+hide_sidebar: true
 folder: tags
 ---
 {% include taglogic.html %}


### PR DESCRIPTION
[このページ](http://api-docs.bocco.me/tag_tutorial.html)に不要なサイドバーが出ていたので削除しました
