### PR TITLE
登録フォームのリンクを変更

### DIFF
--- a/index.md
+++ b/index.md
@@ -17,7 +17,8 @@ BOCCO API の現在のステートはベータであり、実験的な段階に�
 
 お申し込み後5営業日以内に、APIキーなどを個別にご連絡差し上げます。
 
-<a class='btn btn-primary' href='https://docs.google.com/forms/d/e/1FAIpQLSeRjTaH4j2s8-JdyvFmf8vH6Lj4ZRrp78AZufrU0pVVv9JJrA/viewform' target='_blank'>BOCCO API に申し込む</a>
+<a class='btn btn-primary' href='https://docs.google.com/forms/d/e/1FAIpQLSd5OvrkDXLrX8SIDn84MPco2xtxn1u4sIN4daR2Ppf5fcE0eA/viewform' target='_blank'>BOCCO API に申し込む</a>
+
 
 ## ライブラリ
 


### PR DESCRIPTION
API申込フォームの喪失によりフォーム再構築したのに伴いリンク先を変更。